### PR TITLE
Fix bug where DateTime parse error always prevented Defence Request Creation

### DIFF
--- a/app/controllers/defence_requests_controller.rb
+++ b/app/controllers/defence_requests_controller.rb
@@ -29,16 +29,6 @@ class DefenceRequestsController < BaseController
 
 
   def defence_request_params
-    time_of_arrival = DateTime.parse(
-      params[:defence_request]['time_of_arrival(1i)'] +
-        params[:defence_request]['time_of_arrival(2i)'] +
-        params[:defence_request]['time_of_arrival(3i)'] + ' ' +
-        params[:defence_request]['time_of_arrival(4i)'] + ':' +
-        params[:defence_request]['time_of_arrival(5i)']
-    )
-
-    params[:defence_request]['time_of_arrival'] = time_of_arrival
-
     params.require(:defence_request).permit(:solicitor_type,
                                           :solicitor_name,
                                           :solicitor_firm,
@@ -46,6 +36,7 @@ class DefenceRequestsController < BaseController
                                           :phone_number,
                                           :detainee_surname,
                                           :detainee_first_name,
+                                          :time_of_arrival,
                                           :gender,
                                           :adult,
                                           :date_of_birth,

--- a/spec/features/defence_request_creation_spec.rb
+++ b/spec/features/defence_request_creation_spec.rb
@@ -40,6 +40,7 @@ RSpec.feature 'defence request creation' do
       click_button 'Create Defence request'
     end
     expect(page).to have_content 'Bob Smith'
+    expect(page).to have_content 'DefenceRequest successfully created'
   end
 
   scenario 'selecting own solicior and choosing from search box', js: true do


### PR DESCRIPTION


Not sure how long this bug has existed for, but the
feature spec was still passing because "Bob Smith"
was part of the params printed in the 500 page for
the error, test is now more robust