### PR TITLE
Fix bug for submitting no scheme

### DIFF
--- a/app/models/defence_request.rb
+++ b/app/models/defence_request.rb
@@ -9,7 +9,7 @@ class DefenceRequest < ActiveRecord::Base
             :allegations,
             length: { minimum: 5 }
 
-  validates :gender, :date_of_birth, :time_of_arrival, :custody_number, :scheme, presence: true
+  validates :gender, :date_of_birth, :time_of_arrival, :custody_number, presence: true
   validates :phone_number, phony_plausible: true
 
   SCHEMES = [ 'No Scheme',

--- a/spec/features/defence_request_creation_spec.rb
+++ b/spec/features/defence_request_creation_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'defence request creation' do
     create_cso_and_login
   end
 
-  scenario 'Filling in form manually for own solicitor' do
+  scenario 'Filling in form manually for own solicitor', js: true do
     visit root_path
     click_link 'New Defence Request'
     expect(page).to have_content ('New Defence Request')
@@ -18,7 +18,6 @@ RSpec.feature 'defence request creation' do
       within '.details' do
         fill_in 'Solicitor Name', with: 'Bob Smith'
         fill_in 'Solicitor Firm', with: 'Acme Solicitors'
-        select('Brighton Scheme 1', from: 'defence_request[scheme]')
         fill_in 'Phone Number', with: '0207 284 0000'
         fill_in 'Custody Number', with: '#CUST-01234'
         fill_in 'Allegations', with: 'BadMurder'

--- a/spec/models/defence_request_spec.rb
+++ b/spec/models/defence_request_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe DefenceRequest, type: :model do
     it { expect(subject).to validate_presence_of :date_of_birth }
     it { expect(subject).to validate_presence_of :time_of_arrival }
     it { expect(subject).to validate_presence_of :custody_number }
-    it { expect(subject).to validate_presence_of :scheme }
-
 
     it { expect(subject).to ensure_length_of(:solicitor_name).is_at_least(5) }
     it { expect(subject).to ensure_length_of(:solicitor_firm).is_at_least(5) }


### PR DESCRIPTION
The scheme field was disabled, and not being sent
in the form, leading to a validation error. Wasn't
picked up because the test didn't enable js. Just
remove the validation on scheme as we can use nil
to represent No scheme.