### PR TITLE
Switch validations based on solicitor type

### DIFF
--- a/app/models/defence_request.rb
+++ b/app/models/defence_request.rb
@@ -22,15 +22,18 @@ class DefenceRequest < ActiveRecord::Base
 
   before_save :format_phone_number
 
-  validates :solicitor_name,
-            :solicitor_firm,
-            :detainee_name,
+  validates :detainee_name,
             :allegations,
-            :phone_number,
             :gender,
             :date_of_birth,
             :time_of_arrival,
             :custody_number, presence: true
+
+  validates :scheme, presence: true, if: :duty_solicitor?
+
+  validates :solicitor_name,
+            :solicitor_firm,
+            :phone_number, presence: true, if: :own_solicitor?
 
   audited
 
@@ -39,11 +42,18 @@ class DefenceRequest < ActiveRecord::Base
               'Brighton Scheme 2',
               'Brighton Scheme 3']
 
+  def duty_solicitor?
+    solicitor_type == "duty"
+  end
+
+  def own_solicitor?
+    solicitor_type == "own"
+  end
+
   private
 
   def format_phone_number
     self.phone_number = self.phone_number.gsub(/\D/, '')
   end
-
 
 end

--- a/spec/models/defence_request_spec.rb
+++ b/spec/models/defence_request_spec.rb
@@ -1,17 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe DefenceRequest, type: :model do
-  describe 'states' do
+  describe 'validations' do
 
     it { expect(subject).to validate_presence_of :gender }
     it { expect(subject).to validate_presence_of :date_of_birth }
     it { expect(subject).to validate_presence_of :time_of_arrival }
     it { expect(subject).to validate_presence_of :custody_number }
-    it { expect(subject).to validate_presence_of :phone_number }
-    it { expect(subject).to validate_presence_of :solicitor_name }
-    it { expect(subject).to validate_presence_of :solicitor_firm }
     it { expect(subject).to validate_presence_of :detainee_name }
     it { expect(subject).to validate_presence_of :allegations }
+
+    context 'own_solicitor' do
+      before do
+        subject.solicitor_type = "own"
+      end
+      it { expect(subject).to validate_presence_of :solicitor_name }
+      it { expect(subject).to validate_presence_of :solicitor_firm }
+      it { expect(subject).to validate_presence_of :phone_number }
+      it { expect(subject).to_not validate_presence_of :scheme }
+    end
+
+    context 'duty solicitor' do
+      before do
+        subject.solicitor_type = "duty"
+      end
+      it { expect(subject).to validate_presence_of :scheme }
+      it { expect(subject).to_not validate_presence_of :solicitor_name }
+      it { expect(subject).to_not validate_presence_of :solicitor_firm }
+      it { expect(subject).to_not validate_presence_of :phone_number }
+    end
   end
 
   describe 'states' do


### PR DESCRIPTION
Put some proper validations in based on solicitor type, this story: https://www.pivotaltracker.com/story/show/86712262 keeps failing because we are currently validating presence of solicitor name, etc