### PR TITLE
Only open defence requests if they can transition

### DIFF
--- a/app/controllers/defence_requests_controller.rb
+++ b/app/controllers/defence_requests_controller.rb
@@ -3,7 +3,7 @@ class DefenceRequestsController < BaseController
   before_action :find_defence_request, only: [:edit, :update, :close]
 
   def index
-    @open_requests = policy_scope(DefenceRequest).open.order(created_at: :asc)
+    @open_requests = policy_scope(DefenceRequest).opened.order(created_at: :asc)
     @new_requests = policy_scope(DefenceRequest).created.order(created_at: :asc)
   end
 
@@ -37,7 +37,7 @@ class DefenceRequestsController < BaseController
   end
 
   def update
-    @defence_request.open if current_user.cco?
+    @defence_request.open if policy(@defence_request).open?
 
     if @defence_request.update_attributes(defence_request_params)
       redirect_to(defence_requests_path, notice: flash_message(:update, DefenceRequest))
@@ -47,7 +47,7 @@ class DefenceRequestsController < BaseController
   end
 
   def refresh_dashboard
-    @open_requests = policy_scope(DefenceRequest).open.order(created_at: :asc)
+    @open_requests = policy_scope(DefenceRequest).opened.order(created_at: :asc)
     @new_requests = policy_scope(DefenceRequest).created.order(created_at: :asc)
 
     respond_to do |format|

--- a/app/models/defence_request.rb
+++ b/app/models/defence_request.rb
@@ -3,20 +3,20 @@ class DefenceRequest < ActiveRecord::Base
 
   state_machine auto_scopes: true do
     state :created # first one is initial state
-    state :open
+    state :opened
     state :closed
     state :finished
 
     event :open do
-      transitions from: [:created], to: :open
+      transitions from: [:created], to: :opened
     end
 
     event :finish do
-      transitions from: [:open], to: :finished
+      transitions from: [:opened], to: :finished
     end
 
     event :close do
-      transitions from: [:created, :open], to: :closed
+      transitions from: [:created, :opened], to: :closed
     end
   end
 

--- a/app/policies/defence_request_policy.rb
+++ b/app/policies/defence_request_policy.rb
@@ -54,4 +54,8 @@ class DefenceRequestPolicy < ApplicationPolicy
     user.cco?
   end
 
+  def open?
+    user.cco? && record.can_transition?(:open)
+  end
+
 end

--- a/spec/factories/defence_request.rb
+++ b/spec/factories/defence_request.rb
@@ -20,7 +20,7 @@ FactoryGirl.define do
     state 'created'
   end
 
-  trait :open do
-    state 'open'
+  trait :opened do
+    state 'opened'
   end
 end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature 'Defence request dashboard' do
     end
 
     let!(:dr_created) { create(:defence_request, :created) }
-    let!(:dr_open1) { create(:defence_request, :open) }
-    let!(:dr_open2) { create(:defence_request, :open) }
+    let!(:dr_open1) { create(:defence_request, :opened) }
+    let!(:dr_open2) { create(:defence_request, :opened) }
 
     scenario 'i am redirected to my dashboard at login' do
       expect(page).to have_content('Custody Suite Officer Dashboard')
@@ -115,7 +115,7 @@ RSpec.feature 'Defence request dashboard' do
     end
 
     let!(:dr_created) { create(:defence_request, :created) }
-    let!(:dr_open) { create(:defence_request, :open) }
+    let!(:dr_open) { create(:defence_request, :opened) }
 
     scenario 'i am redirected to my dashboard at login' do
       expect(page).to have_content('Call Center Operative Dashboard')
@@ -170,7 +170,7 @@ RSpec.feature 'Defence request dashboard' do
       within ".new_defence_requests" do
         click_link 'Edit'
       end
-      
+
       within '.details' do
         fill_in 'Solicitor Name', with: 'Bob Smith'
       end

--- a/spec/features/defence_request_management_spec.rb
+++ b/spec/features/defence_request_management_spec.rb
@@ -202,7 +202,7 @@ RSpec.feature 'defence request creation' do
 
       let!(:dr_1) { create(:defence_request) }
 
-      scenario 'editing a DR' do
+      scenario 'editing a DR (multiple times)' do
         visit root_path
         within "#defence_request_#{dr_1.id}" do
           click_link 'Edit'
@@ -214,6 +214,9 @@ RSpec.feature 'defence request creation' do
           click_link 'Edit'
         end
         expect(page).to have_field 'DSCC Number', with: 'NUMBERWANG'
+        fill_in 'DSCC Number', with: 'T-1000'
+        click_button 'Update Defence Request'
+        expect(page).to have_content 'Defence Request successfully updated'
       end
 
     end

--- a/spec/models/defence_request_spec.rb
+++ b/spec/models/defence_request_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DefenceRequest, type: :model do
       expect(subject.can_transition? :finish).to eq false
       # state = open
       expect{ subject.open }.to_not raise_error
-      expect(subject.current_state).to eql :open
+      expect(subject.current_state).to eql :opened
       expect(subject.can_transition? :open).to eq false
       expect(subject.can_transition? :close).to eq true
       expect(subject.can_transition? :created).to eq false
@@ -55,7 +55,7 @@ RSpec.describe DefenceRequest, type: :model do
       expect(subject.can_transition? :finish).to eq false
       # state = finished
       expect{ subject.finish }.to raise_error(Transitions::InvalidTransition)
-      subject.update_current_state(:open)
+      subject.update_current_state(:opened)
       expect{ subject.finish }.to_not raise_error
       expect(subject.current_state).to eql :finished
       expect(subject.can_transition? :open).to eq false

--- a/spec/policies/defence_requests_policy_spec.rb
+++ b/spec/policies/defence_requests_policy_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe DefenceRequestPolicy do
   context "Call Center Operatives" do
     let(:user) { FactoryGirl.create(:cco_user)}
 
-    [:index, :refresh_dashboard, :dscc_number_edit].each do |action|
+    [:index, :refresh_dashboard, :dscc_number_edit, :open].each do |action|
       specify { expect(subject).to permit_action(action) }
     end
 


### PR DESCRIPTION
- Also added in a policy for opening DRs to keep
consistent with our guarding of actions.