### PR TITLE
Stop rendering all DR's after refresh

### DIFF
--- a/app/policies/defence_request_policy.rb
+++ b/app/policies/defence_request_policy.rb
@@ -22,6 +22,10 @@ class DefenceRequestPolicy < ApplicationPolicy
     cso || cco || solicitor
   end
 
+  def refresh_dashboard?
+    index?
+  end
+
   def show?
     cso || cco || solicitor
   end
@@ -44,10 +48,6 @@ class DefenceRequestPolicy < ApplicationPolicy
 
   def solicitors_search?
     cso
-  end
-
-  def refresh_dashboard?
-    cso || cco || solicitor
   end
 
   def feedback?

--- a/app/views/defence_requests/refresh_dashboard.js.erb
+++ b/app/views/defence_requests/refresh_dashboard.js.erb
@@ -1,4 +1,4 @@
 $('.dashboard tbody').html('');
-$('.dashboard tbody').append("<%= escape_javascript(render 'defence_requests_table_body', requests: @created_requests, type: 'created') %>");
-$('.dashboard tbody').append("<%= escape_javascript(render 'defence_requests_table_body', requests: @open_requests, type: 'open') %>");
-$('.dashboard tbody').append("<%= escape_javascript(render 'defence_requests_table_body', requests: @accepted_requests, type: 'accepted') %>");
+$('.dashboard tbody').append("<%= escape_javascript(render 'defence_requests_table_body', requests: @created_requests, type: 'created') if policy(:defence_request).view_created_requests? %>");
+$('.dashboard tbody').append("<%= escape_javascript(render 'defence_requests_table_body', requests: @open_requests, type: 'open') if policy(:defence_request).view_open_requests? %>");
+$('.dashboard tbody').append("<%= escape_javascript(render 'defence_requests_table_body', requests: @accepted_requests, type: 'accepted') if policy(:defence_request).view_accepted_requests? %>");

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -199,6 +199,8 @@ RSpec.feature 'Defence request dashboard' do
     let!(:solicitor_dr) { create(:defence_request, :accepted) }
     let!(:other_solicitor_dr) { create(:defence_request, :accepted) }
     let!(:other_solicitor) { create(:solicitor_user) }
+    let!(:solicitor_dr_not_accepted) { create(:defence_request, :opened, dscc_number: '98765', solicitor: solicitor_dr.solicitor) }
+    let!(:created_dr) { create(:defence_request, :created, dscc_number: '98765', solicitor: solicitor_dr.solicitor) }
 
     before :each do
       login_as_user(solicitor_dr.solicitor.email)
@@ -217,6 +219,28 @@ RSpec.feature 'Defence request dashboard' do
       within ".accepted_defence_request" do
         expect(page).to_not have_content(other_solicitor_dr.solicitor_name)
       end
+    end
+
+    scenario 'after the refresh i can still see ONLY the correct data', js: true do
+      visit defence_requests_path
+
+      within ".accepted_defence_request" do
+        expect(page).to have_content(solicitor_dr.detainee_name)
+        expect(page).to_not have_content(solicitor_dr_not_accepted.detainee_name)
+      end
+      expect(page).to_not have_selector(".created_defence_request")
+      expect(page).to_not have_selector(".open_defence_request")
+
+      sleep(4)
+      wait_for_ajax
+
+      within ".accepted_defence_request" do
+        expect(page).to have_content(solicitor_dr.detainee_name)
+        expect(page).to_not have_content(solicitor_dr_not_accepted.detainee_name)
+      end
+
+      expect(page).to_not have_selector(".created_defence_request")
+      expect(page).to_not have_selector(".open_defence_request")
     end
   end
 


### PR DESCRIPTION
- use policies to limit what is added to the dashboard afte rthe refresh