### PR TITLE
Ignore coverage dir generated by simplecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@
 /log/*
 !/log/.keep
 /tmp
+/coverage
 
 .env


### PR DESCRIPTION
Probably should have been in the simplecov PR.