### PR TITLE
Use field translations for validation message

### DIFF
--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,4 +1,4 @@
 <%= render 'shared/content/error_messages', object: object %>
 <% if object.errors.any? %>
-<%= yield :error_messages %>
+  <%= yield :error_messages %>
 <% end %>

--- a/app/views/shared/content/_error_messages.en.html.erb
+++ b/app/views/shared/content/_error_messages.en.html.erb
@@ -1,13 +1,9 @@
 <% content_for :error_messages do %>
   <section class="error-summary" id="form_errors" tabindex="-1">
     <h3 id="page-error-heading">You need to fix the errors on this page before continuing.</h3>
-
-    <p>See highlighted errors below.</p>
-    <span class="visuallyhidden">Errors are listed as links below, click to select the field that needs correcting.</span>
-    <ul>
       <% object.errors.messages.each do |field, message| %>
         <li>
-          <%= "#{field}: #{message.is_a?(Array) ? message.first : message}" %>
+          <%= "#{t(field)}: #{message.is_a?(Array) ? message.first : message}" %>
         </li>
       <% end %>
     </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
   delete: "Delete"
   details: "Details"
   detainee: "Detainee"
+  detainee_age: "Detainee age"
   detainee_details: "Detainee details"
   detainee_dob: "Detainee date of birth (optional)"
   detainee_name: "Detainee name"

--- a/spec/features/defence_request_management_spec.rb
+++ b/spec/features/defence_request_management_spec.rb
@@ -175,7 +175,7 @@ RSpec.feature 'defence request creation' do
         end
         expect(page).to have_content('Close the Defence Request')
         click_button 'Close'
-        expect(page).to have_content("feedback: can't be blank")
+        expect(page).to have_content("Feedback: can't be blank")
         expect(page).to have_content('Close the Defence Request')
 
         fill_in 'Feedback', with: 'I just cant take it any more...'
@@ -193,7 +193,7 @@ RSpec.feature 'defence request creation' do
         click_link 'Close'
         expect(page).to have_content('Close the Defence Request')
         click_button 'Close'
-        expect(page).to have_content("feedback: can't be blank")
+        expect(page).to have_content("Feedback: can't be blank")
         expect(page).to have_content('Close the Defence Request')
 
         fill_in 'Feedback', with: 'I just cant take it any more...'
@@ -218,7 +218,7 @@ RSpec.feature 'defence request creation' do
         end
         expect(page).to have_content('Close the Defence Request')
         click_button 'Close'
-        expect(page).to have_content("feedback: can't be blank")
+        expect(page).to have_content("Feedback: can't be blank")
         expect(page).to have_content('Close the Defence Request')
 
         fill_in 'Feedback', with: 'I just cant take it any more...'


### PR DESCRIPTION
Not sure if there was something else in this story because it is a 2 pointer? Maybe its just overestimated.

The field highlighting still doesn't work, but that is a more complicated story because it relies on the form builder being used, or the styles for the form break which we are not doing. 