### PR TITLE
Don't override error_proc in application config

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -120,15 +120,15 @@ h5.user-role {
   margin-right: 1em;
 }
 
-label + input, label + textarea {
-  width: 80%;
-}
-
 .text-field {
   text-transform: none;
   border: 1px solid #bbb;
   margin: 0 0 1em;
   padding: 0.5em;
+}
+
+.text-field-wide {
+  width: 80%;
 }
 
 .solicitor_search_wrapper {

--- a/app/views/defence_requests/_new_form.html.erb
+++ b/app/views/defence_requests/_new_form.html.erb
@@ -8,19 +8,19 @@
       <div class="details panel">
         <div class="">
           <%= f.label :solicitor_name, t('full_name')%>
-          <%= f.text_field :solicitor_name, class: 'text-field' %>
+          <%= f.text_field :solicitor_name, class: 'text-field text-field-wide' %>
         </div>
 
         <div class="form-group">
           <%= f.label :solicitor_firm, t('name_of_firm')%>
-          <%= f.text_field :solicitor_firm, class: 'text-field' %>
+          <%= f.text_field :solicitor_firm, class: 'text-field text-field-wide' %>
         </div>
 
         <%= f.text_field :solicitor_email, type: :hidden %>
 
         <div class="form-group">
           <%= f.label :phone_number, t('telephone_number') %>
-          <%= f.text_field :phone_number, class: 'text-field' %>
+          <%= f.text_field :phone_number, class: 'text-field text-field-wide' %>
         </div>
         <% if @policy.solicitor_time_of_arrival? %>
         <div class="form-group">
@@ -38,7 +38,7 @@
     <div class="detainee panel">
       <div class="form-group">
         <%= f.label :detainee_name, t('full_name') %>
-        <%= f.text_field :detainee_name, class: 'text-field' %>
+        <%= f.text_field :detainee_name, class: 'text-field text-field-wide' %>
       </div>
 
       <div class="form-group">
@@ -118,12 +118,12 @@
 
       <div class="form-group">
         <%= f.label :allegations, t('allegations') %>
-        <%= f.text_field :allegations, class: 'text-field' %>
+        <%= f.text_field :allegations, class: 'text-field text-field-wide' %>
       </div>
 
       <div class="form-group hidden" id='scheme-field'>
         <%= f.label :scheme, t('scheme'), class: 'form-label-bold' %>
-        <%= f.text_field :scheme, class: 'text-field' %>
+        <%= f.text_field :scheme, class: 'text-field text-field-wide' %>
       </div>
 
       <div class="form-group">
@@ -142,13 +142,13 @@
 
       <div class="form-group">
         <%= f.label :comments, t('comments') %>
-        <%= f.text_area :comments, label: t('comments'), rows: '5', class: 'text-field' %>
+        <%= f.text_area :comments, label: t('comments'), rows: '5', class: 'text-field text-field-wide' %>
       </div>
 
       <%- if @policy.dscc_number_edit? %>
         <div class="form-group">
           <%= f.label :dscc_number, t('dscc_number'), class: 'form-label-bold' %>
-          <%= f.text_field :dscc_number, readonly: !@policy.dscc_number_edit?, class: 'text-field' %>
+          <%= f.text_field :dscc_number, readonly: !@policy.dscc_number_edit?, class: 'text-field text-field-wide' %>
         </div>
       <%- end %>
     </div>

--- a/app/views/defence_requests/form_partials/_case_details.html.erb
+++ b/app/views/defence_requests/form_partials/_case_details.html.erb
@@ -1,11 +1,11 @@
 <div class="form-group">
   <%= f.label :allegations, t('allegations') %>
-  <%= f.text_field :allegations, class: 'text-field' %>
+  <%= f.text_field :allegations, class: 'text-field text-field-wide' %>
 </div>
 
 <div class="form-group hidden" id='scheme-field'>
   <%= f.label :scheme, t('scheme'), class: 'form-label-bold' %>
-  <%= f.text_field :scheme, class: 'text-field' %>
+  <%= f.text_field :scheme, class: 'text-field text-field-wide' %>
 </div>
 
 <div class="form-group">
@@ -15,5 +15,5 @@
 
 <div class="form-group">
   <%= f.label :comments, t('comments') %>
-  <%= f.text_area :comments, label: t('comments'), rows: '5', class: 'text-field' %>
+  <%= f.text_area :comments, label: t('comments'), rows: '5', class: 'text-field text-field-wide' %>
 </div>

--- a/app/views/defence_requests/form_partials/_case_dscc_number.html.erb
+++ b/app/views/defence_requests/form_partials/_case_dscc_number.html.erb
@@ -1,4 +1,4 @@
 <div class="form-group">
   <%= f.label :dscc_number, t('dscc_number'), class: 'form-label-bold' %>
-  <%= f.text_field :dscc_number, readonly: !@policy.dscc_number_edit?, class: 'text-field' %>
+  <%= f.text_field :dscc_number, readonly: !@policy.dscc_number_edit?, class: 'text-field text-field-wide' %>
 </div>

--- a/app/views/defence_requests/form_partials/_detainee_details.html.erb
+++ b/app/views/defence_requests/form_partials/_detainee_details.html.erb
@@ -1,6 +1,6 @@
 <div class="form-group">
   <%= f.label :detainee_name, t('full_name') %>
-  <%= f.text_field :detainee_name, class: 'text-field' %>
+  <%= f.text_field :detainee_name, class: 'text-field text-field-wide' %>
 </div>
 <div class="form-group">
   <fieldset class="inline">

--- a/app/views/defence_requests/form_partials/_solicitor_details.html.erb
+++ b/app/views/defence_requests/form_partials/_solicitor_details.html.erb
@@ -1,19 +1,19 @@
 <div class="">
   <%= f.label :solicitor_name, t('full_name') %>
-  <%= f.text_field :solicitor_name, class: 'text-field' %>
+  <%= f.text_field :solicitor_name, class: 'text-field text-field-wide' %>
 </div>
 
 <div class="form-group">
   <%= f.label :solicitor_firm, t('name_of_firm') %>
-  <%= f.text_field :solicitor_firm, class: 'text-field' %>
+  <%= f.text_field :solicitor_firm, class: 'text-field text-field-wide' %>
 </div>
 
 <div class="form-group">
   <%= f.label :solicitor_email, t('solicitor_email') %>
-  <%= f.text_field :solicitor_email, class: 'text-field' %>
+  <%= f.text_field :solicitor_email, class: 'text-field text-field-wide' %>
 </div>
 
 <div class="form-group">
   <%= f.label :phone_number, t('telephone_number') %>
-  <%= f.text_field :phone_number, class: 'text-field' %>
+  <%= f.text_field :phone_number, class: 'text-field text-field-wide' %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,9 +31,6 @@ module DefenceSolicitor
     config.relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT'] || ''
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
-    config.action_view.field_error_proc = Proc.new { |html_tag, instance|
-      html_tag
-    }
     config.use_govuk_elements_form_builder = false
     # app title appears in the header bar
     config.proposition_title = 'Defence Solicitor Deployment Service'


### PR DESCRIPTION
Use a class to set the field width so that error_proc doesn't need
to be overridden because it wraps the label and field separately
and breaks the adjacent selector. This also makes it work in IE6.