### PR TITLE
Refactor policy and transitions

### DIFF
--- a/app/controllers/defence_requests_controller.rb
+++ b/app/controllers/defence_requests_controller.rb
@@ -1,6 +1,6 @@
 class DefenceRequestsController < BaseController
 
-  before_action :find_defence_request, :set_policy, only: [:solicitor_time_of_arrival, :edit, :update, :feedback, :close, :open, :accepted, :resend_details]
+  before_action :find_defence_request, :set_policy, only: [:solicitor_time_of_arrival, :edit, :update, :feedback, :close, :open, :accept, :resend_details]
 
   before_action ->(c) { authorize defence_request, "#{c.action_name}?" }
 
@@ -89,12 +89,12 @@ class DefenceRequestsController < BaseController
   def close
   end
 
-  def accepted
+  def accept
     @defence_request.accept
     if @defence_request.save
-      redirect_to(defence_requests_path, notice: flash_message(:accepted, DefenceRequest))
+      redirect_to(defence_requests_path, notice: flash_message(:accept, DefenceRequest))
     else
-      redirect_to(defence_requests_path, notice: flash_message(:failed_accepted, DefenceRequest))
+      redirect_to(defence_requests_path, notice: flash_message(:failed_accept, DefenceRequest))
     end
   end
 

--- a/app/models/defence_request.rb
+++ b/app/models/defence_request.rb
@@ -22,7 +22,7 @@ class DefenceRequest < ActiveRecord::Base
     end
 
     event :accept, success: :send_solicitor_case_details do
-      transitions from: [:opened], to: :accepted
+      transitions from: [:opened], to: :accepted, guard: :dscc_number?
     end
 
     event :finish do

--- a/app/policies/defence_request_policy.rb
+++ b/app/policies/defence_request_policy.rb
@@ -83,9 +83,6 @@ class DefenceRequestPolicy < ApplicationPolicy
   end
 
   def accept?
-
-  def accepted?
-    cco && can_transition?(:accept) && has_dscc_number?
     cco && record.can_execute_accept?
   end
 

--- a/app/policies/defence_request_policy.rb
+++ b/app/policies/defence_request_policy.rb
@@ -51,11 +51,11 @@ class DefenceRequestPolicy < ApplicationPolicy
   end
 
   def feedback?
-    (cso || cco) && can_transition?(:close)
+    (cso || cco) && record.can_execute_close?
   end
 
   def close?
-    (cso || cco) && can_transition?(:close)
+    (cso || cco) && record.can_execute_close?
   end
 
   def dscc_number_edit?
@@ -79,15 +79,14 @@ class DefenceRequestPolicy < ApplicationPolicy
   end
 
   def open?
-    cco && can_transition?(:open)
+    cco && record.can_execute_open?
   end
 
   def accept?
-    cco && can_transition?(:accept) && has_dscc_number?
-  end
 
   def accepted?
     cco && can_transition?(:accept) && has_dscc_number?
+    cco && record.can_execute_accept?
   end
 
   def view_open_requests?
@@ -116,10 +115,6 @@ class DefenceRequestPolicy < ApplicationPolicy
 
   private
 
-  def can_transition?(state)
-    record.can_transition?(state)
-  end
-
   def cso
     user.cso?
   end
@@ -130,10 +125,6 @@ class DefenceRequestPolicy < ApplicationPolicy
 
   def solicitor
     user.solicitor?
-  end
-
-  def has_dscc_number?
-    record.dscc_number?
   end
 
 end

--- a/app/views/defence_requests/_actions.html.erb
+++ b/app/views/defence_requests/_actions.html.erb
@@ -2,5 +2,5 @@
 <%= link_to t('close'), close_defence_request_path(def_req) if policy(def_req).close? %>
 <%= link_to t('edit'), edit_defence_request_path(def_req) if policy(def_req).edit? %>
 <%= button_to t('open'), open_defence_request_path(def_req), method: :put if policy(def_req).open? %>
-<%= button_to t('accepted'), accepted_defence_request_path(def_req), method: :patch if policy(def_req).accept? %>
+<%= button_to t('accepted'), accept_defence_request_path(def_req), method: :patch if policy(def_req).accept? %>
 <%= button_to t('resend_details'), resend_details_defence_request_path(def_req), onclick: "return confirm('Are you sure?')", method: :post if policy(def_req).resend_details? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,13 +97,13 @@ en:
   year: "Year"
 
   models:
-    accepted: "%{model} was not marked as accepted"
+    accept: "%{model} was not marked as accepted"
     close: "%{model} successfully closed"
     create: "%{model} successfully created"
     destroy: "%{model} successfully deleted"
     details_sent: "Details successfully sent"
     dscc_number_required: "A Valid DSCC number is required to update and accept a %{model}"
-    failed_accepted: "%{model} was not marked as accepted"
+    failed_accept: "%{model} was not marked as accepted"
     failed_close: "%{model} was not closed"
     failed_destroy: "%{model} was not deleted"
     failed_details_sent: "Details were not sent"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
       get 'close'
       patch 'close' => 'defence_requests#feedback', as: 'close_feedback'
       put 'open'
-      patch 'accepted' => 'defence_requests#accepted', as: 'accepted'
+      patch 'accept' => 'defence_requests#accept'
       post 'resend_details'
       patch 'solicitor_time_of_arrival' => 'defence_requests#solicitor_time_of_arrival', as: 'solicitor_time_of_arrival'
     end

--- a/spec/factories/defence_request.rb
+++ b/spec/factories/defence_request.rb
@@ -50,6 +50,10 @@ FactoryGirl.define do
     state 'closed'
   end
 
+  trait :finished do
+    state 'finished'
+  end
+
   trait :with_dscc_number do
     state 'opened'
     dscc_number '123456'

--- a/spec/policies/defence_requests_policy_spec.rb
+++ b/spec/policies/defence_requests_policy_spec.rb
@@ -127,7 +127,6 @@ RSpec.describe DefenceRequestPolicy do
         :update,
         :close,
         :feedback,
-        :accepted,
         :accept,
         :case_details_edit,
         :detainee_details_edit,


### PR DESCRIPTION
Previously we had to duplicate logic in the policy
because `can_transition` does not respect guards.

Also remove unused `accepted?` method.