### PR TITLE
Coverage artifacts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :test do
   gem 'webmock'
   gem 'factory_girl_rails'
   gem 'simplecov', require: false
+  gem "codeclimate-test-reporter", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
     celluloid (0.16.0)
       timers (~> 4.0.0)
     cliver (0.3.2)
+    codeclimate-test-reporter (0.4.7)
+      simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
@@ -303,6 +305,7 @@ PLATFORMS
 DEPENDENCIES
   audited-activerecord (~> 4.0.0)
   capybara
+  codeclimate-test-reporter
   coffee-rails (~> 4.1.0)
   database_cleaner
   devise (~> 3.4.1)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,9 +1,16 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 unless ENV['NO_COVERAGE']
   require 'simplecov'
-  # on circleci change the output dir to the artifacts
+
+  # On circleci change the output dir to the artifacts
   if ENV['CIRCLE_ARTIFACTS']
     SimpleCov.coverage_dir File.join(ENV['CIRCLE_ARTIFACTS'], "coverage")
+  end
+
+  # Report code coverage to codeclimate
+  if ENV['CODECLIMATE_REPO_TOKEN']
+    require "codeclimate-test-reporter"
+    CodeClimate::TestReporter.start
   end
 
   SimpleCov.minimum_coverage 90 # will return non-zero exit code if < 90%

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,15 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'simplecov'
-if ENV['CIRCLE_ARTIFACTS']
-    dir = File.join(ENV['CIRCLE_ARTIFACTS'], "coverage")
-    SimpleCov.coverage_dir(dir)
+unless ENV['NO_COVERAGE']
+  require 'simplecov'
+  # on circleci change the output dir to the artifacts
+  if ENV['CIRCLE_ARTIFACTS']
+    SimpleCov.coverage_dir File.join(ENV['CIRCLE_ARTIFACTS'], "coverage")
+  end
+
+  SimpleCov.minimum_coverage 90 # will return non-zero exit code if < 90%
+  SimpleCov.refuse_coverage_drop # will return non-zero exit code if coverage drops
+  SimpleCov.start 'rails'
 end
-SimpleCov.start 'rails'
 
 ENV["RAILS_ENV"] ||= 'test'
 require 'spec_helper'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,7 +37,7 @@ end
 
 Capybara.javascript_driver = :poltergeist
 
-WebMock.disable_net_connect!(:allow_localhost => true)
+WebMock.disable_net_connect!(allow_localhost: true, allow: ['codeclimate.com'])
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 


### PR DESCRIPTION
* NO_COVERAGE=true will disable coverage generation in tests
* CodeClimate now notified about test coverage
* Minimum coverage of 90% required for a green test run 