### PR TITLE
Add /status route

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,0 +1,11 @@
+class StatusController < ApplicationController
+  skip_before_filter :authenticate_user!
+
+  def index
+    respond_to do |format|
+      format.json { render json: {"status" => "OK"} }
+      format.xml { render xml: {"Status" => "OK"}.to_xml(root: 'Response') }
+      format.any { render text: "OK"}
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     end
   end
 
+  get '/status' => 'status#index'
   get '/help', controller: :static, action: :help, as: :help
   get '/maintenance', controller: :static, action: :maintenance, as: :maintenance
   get '/cookies', controller: :static, action: :cookies, as: :cookies

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe StatusController, type: :controller do
+
+  describe "GET index" do
+    it 'returns 200 status code' do
+      get :index
+      expect(response).to have_http_status(:ok)
+    end
+
+    context 'HTML request' do
+      it 'returns OK in body' do
+        get :index
+        expect(response.body).to include("OK")
+      end
+    end
+
+    context 'JSON request' do
+      it 'returns a JSON status "OK"' do
+        get :index, format: 'json'
+        expect(JSON.parse response.body.strip).to eq({"status" => "OK"})
+      end
+    end
+
+    context 'XML request' do
+      it 'returns a XML status "OK"' do
+        get :index, format: 'xml'
+        expect(response.body.strip).to eq("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Status>OK</Status>\n</Response>")
+      end
+    end
+
+    context 'other MIME type' do
+      it 'returns OK in body' do
+        get :index, format: 'text'
+        expect(response.body).to include("OK")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Simple endpoint that GDS can use to measure uptime

Does not do anything more than respond with "OK" (no DB connectivity checks etc)

Fixes https://www.pivotaltracker.com/story/show/89397814