### PR TITLE
Stop search being submitted by enter on DR form

### DIFF
--- a/app/views/defence_requests/form_partials/_solicitor_search.html.erb
+++ b/app/views/defence_requests/form_partials/_solicitor_search.html.erb
@@ -2,7 +2,7 @@
   <div class="form-group solicitor-search-wrapper">
     <p class="form-hint"><%= t('solicitor_search').html_safe %></p>
     <%= text_field_tag 'q', nil, autocomplete: "off", autofocus: true, class: "no-enter-submit search-text-field text-field" %>
-    <%= button_tag t('search'), class: 'button solicitor-search' %>
+    <%= button_tag t('search'), type: "button", class: 'button solicitor-search' %>
   </div>
   <div class="solicitor-results-list">
   </div>


### PR DESCRIPTION
Not sure when this broke, but the dr form was
submitting the search when enter was pressed on
any field, apparently browsers assume any button
without `type="button"` is a submit button.