### PR TITLE
Validate numerically of detainee age

### DIFF
--- a/app/models/defence_request.rb
+++ b/app/models/defence_request.rb
@@ -47,9 +47,10 @@ class DefenceRequest < ActiveRecord::Base
   validates :detainee_name,
             :allegations,
             :gender,
-            :detainee_age,
             :time_of_arrival,
             :custody_number, presence: true
+
+  validates :detainee_age, numericality: true, presence: true
 
   audited
 

--- a/spec/models/defence_request_spec.rb
+++ b/spec/models/defence_request_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe DefenceRequest, type: :model do
     it { expect(subject).to validate_presence_of :custody_number }
     it { expect(subject).to validate_presence_of :detainee_name }
     it { expect(subject).to validate_presence_of :allegations }
+    it { expect(subject).to validate_numericality_of :detainee_age }
 
-    context 'own_solicitor' do
+    context 'own solicitor' do
       before do
         subject.solicitor_type = "own"
       end


### PR DESCRIPTION
This is the only field on the DR form that needs
to be cast to something, but is not handled by
a field object. We need to validate numerically
or someone could input `"Jeff"` and it would end
up being `0` as `"Jeff".to_i => 0`