### PR TITLE
Delegate form fields to those before casting

### DIFF
--- a/app/forms/defence_request_form.rb
+++ b/app/forms/defence_request_form.rb
@@ -1,7 +1,15 @@
 class DefenceRequestForm
   include ActiveModel::Model
+  extend Forwardable
 
   attr_reader :defence_request, :fields
+
+  DELEGATED_ATTRIBUTES = :solicitor_type, :solicitor_name, :solicitor_firm, :phone_number, :detainee_name,
+           :gender, :detainee_age, :allegations, :scheme, :custody_number, :comments, :feedback
+
+  DELEGATED_ATTRIBUTES.each do |attr_name|
+    def_delegator :@defence_request, "#{attr_name}_before_type_cast", attr_name
+  end
 
   def self.model_name
     ActiveModel::Name.new(self, nil, 'DefenceRequest')
@@ -21,10 +29,6 @@ class DefenceRequestForm
   def register_field field_name, klass, opts={}
     @fields[field_name] = klass.from_persisted_value @defence_request.send field_name
   end
-
-  delegate :solicitor_type, :solicitor_name, :solicitor_firm, :phone_number, :detainee_name,
-           :gender, :detainee_age, :allegations, :scheme, :custody_number, :comments, :feedback,
-           to: :defence_request
 
   def submit(params)
     @fields.select!{ |k, v| params.include?(k) }

--- a/spec/features/cso/defence_request_management_spec.rb
+++ b/spec/features/cso/defence_request_management_spec.rb
@@ -295,6 +295,7 @@ RSpec.feature "Custody Suite Officers managing defence requests" do
         end
         click_button "Update Defence Request"
 
+        expect(page).to have_field "Age", with: "MOOOSE ON THE LOOOSE!?!"
         expect(page).to have_content "You need to fix the errors on this page before continuing"
         expect(page).to have_content "Detainee age: is not a number"
       end


### PR DESCRIPTION
Before: filling in a field like Age as a string 
would cast the value to `0`, which would then be 
resurfaced when the page was re-rendered with
errors. Instead we can delegate to the attribute
before it was cast to refill the form with the
exact values that were input before the attempt
to submit.