### PR TITLE
Stop using non-example emails in factories

### DIFF
--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :user do |user|
-    sequence(:email)            {|n| "barry#{n}@factory.com" }
+    sequence(:email)            {|n| "barry#{n}@factory.example.com" }
     user.password               "password"
     user.password_confirmation  "password"
   end


### PR DESCRIPTION
Noticed this during the ds-auth app setup, which
had copy-pasta config.